### PR TITLE
Add basic login feature

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { TextField, Button, Snackbar, Alert, Paper, Typography } from '@mui/material'
+import PropTypes from 'prop-types'
+
+const Login = ({ onLogin }) => {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [warning, setWarning] = useState('')
+
+  const submitHandler = (e) => {
+    e.preventDefault()
+    if (username === 'admin' && password === 'password') {
+      localStorage.setItem('loggedIn', 'true')
+      if (typeof onLogin === 'function') onLogin()
+    } else {
+      setWarning('Invalid credentials')
+    }
+  }
+
+  return (
+    <Paper
+      elevation={3}
+      sx={{ width: 300, margin: '100px auto', padding: 4, textAlign: 'center' }}
+    >
+      <Typography variant="h5" component="h2" sx={{ marginBottom: 2 }}>
+        Login
+      </Typography>
+      <form onSubmit={submitHandler}>
+        <TextField
+          label="Username"
+          variant="outlined"
+          fullWidth
+          margin="dense"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <TextField
+          label="Password"
+          type="password"
+          variant="outlined"
+          fullWidth
+          margin="dense"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          color="primary"
+          fullWidth
+          sx={{ marginTop: 2 }}
+        >
+          Login
+        </Button>
+      </form>
+      <Snackbar
+        open={Boolean(warning)}
+        autoHideDuration={3000}
+        onClose={() => setWarning('')}
+      >
+        {warning ? <Alert severity="error">{warning}</Alert> : null}
+      </Snackbar>
+    </Paper>
+  )
+}
+
+Login.propTypes = {
+  onLogin: PropTypes.func,
+}
+
+export default Login

--- a/src/Todo.jsx
+++ b/src/Todo.jsx
@@ -3,10 +3,11 @@ import { useState } from 'react'
 import { nanoid } from 'nanoid'
 import TodoList from './TodoList'
 import TodoForm from './TodoForm'
-import { Typography } from '@mui/material';
+import { Typography, Button } from '@mui/material';
+import PropTypes from 'prop-types'
 
 
-const Todo = () => {
+const Todo = ({ onLogout }) => {
     // Sample Data
     const todoItems = [
         {id: 1, name: 'Todo1', edit: false, completed: false},
@@ -140,13 +141,14 @@ const Todo = () => {
     
     const remainingCount = todos.filter(todo => !todo.completed).length
     
-	return(
+        return(
         <React.Fragment>
-                <header style={{width: '80%', paddingTop: '30px', maxWidth: 600, margin: '0 auto'}}>
-                    <h1>
+                <header style={{width: '80%', paddingTop: '30px', maxWidth: 600, margin: '0 auto', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+                    <h1 style={{margin: 0}}>
                         Todo App
                         <img style={{width:'50px', height:'50px', verticalAlign: 'bottom', marginLeft:'10px'}}src="logo.svg" alt="logo"/>
                     </h1>
+                    { onLogout ? <Button variant="outlined" onClick={onLogout}>Logout</Button> : null }
                 </header>
                 <Typography sx={{display: 'block', width: '80%', maxWidth: 600, margin: '20px auto 0', fontWeight: 'bold'}}>
                     <Typography component="span" color='primary' style={{fontSize: '2rem', margin: '0 5px'}}>{remainingCount}</Typography>items left
@@ -158,3 +160,7 @@ const Todo = () => {
 }
 
 export default Todo
+
+Todo.propTypes = {
+    onLogout: PropTypes.func,
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
-import { StrictMode } from 'react'
+import { StrictMode, useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import Todo from './Todo.jsx'
+import Login from './Login.jsx'
 import { createTheme, ThemeProvider, CssBaseline } from "@mui/material";
 
 const theme = createTheme({
@@ -11,11 +12,36 @@ const theme = createTheme({
   },
 });
 
+const App = () => {
+  const [loggedIn, setLoggedIn] = useState(false)
+
+  useEffect(() => {
+    if (localStorage.getItem('loggedIn') === 'true') {
+      setLoggedIn(true)
+    }
+  }, [])
+
+  const handleLogin = () => setLoggedIn(true)
+
+  const handleLogout = () => {
+    localStorage.removeItem('loggedIn')
+    setLoggedIn(false)
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {loggedIn ? (
+        <Todo onLogout={handleLogout} />
+      ) : (
+        <Login onLogin={handleLogin} />
+      )}
+    </ThemeProvider>
+  )
+}
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
-      <CssBaseline/> 
-      <Todo/>
-    </ThemeProvider>
+    <App />
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- add login form with simple credential check
- allow logging out from Todo page
- show Login or Todo page based on login state

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_684b45e74cb8832381310e02461c3ec6